### PR TITLE
tilde replacement disabled on Windows; causes tests to fail

### DIFF
--- a/src/main/java/com/sqlsheet/XlsDriver.java
+++ b/src/main/java/com/sqlsheet/XlsDriver.java
@@ -32,6 +32,7 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.sql.*;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.regex.Matcher;
 
@@ -66,15 +67,26 @@ public class XlsDriver implements java.sql.Driver {
   public static File getHomeFolder() {
     return new File(System.getProperty("user.home"));
   }
+  
+  /** @return are we running on Windows */
+  public static boolean isWindows() {
+      return System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+  }
 
   /**
    * @param uriStr the String representation of an URI containing "~" or "${user.home}"
+   * @param replaceTilde whether or not to replace a ~ in the URI (can have side-effects on Windows)
    * @return the expanded URI (resolving "~" and "${user.home}" to the actual $HOME folder
    */
   public static String resolveHomeUriStr(String uriStr) {
     String homePathStr = getHomeFolder().toURI().getPath();
 
-    String expandedURIStr = uriStr.replaceFirst("~", Matcher.quoteReplacement(homePathStr));
+    String expandedURIStr;
+    if (!isWindows())
+    	expandedURIStr = uriStr.replaceFirst("~", Matcher.quoteReplacement(homePathStr));
+    else
+    	expandedURIStr = uriStr;
+    	
     expandedURIStr =
         expandedURIStr.replaceFirst("\\$\\{user.home\\}", Matcher.quoteReplacement(homePathStr));
 

--- a/src/main/java/com/sqlsheet/stream/XlsSheetIterator.java
+++ b/src/main/java/com/sqlsheet/stream/XlsSheetIterator.java
@@ -21,6 +21,7 @@ import org.apache.poi.hssf.eventusermodel.dummyrecord.LastCellOfRowDummyRecord;
 import org.apache.poi.hssf.eventusermodel.dummyrecord.MissingCellDummyRecord;
 import org.apache.poi.hssf.model.HSSFFormulaParser;
 import org.apache.poi.hssf.record.*;
+import org.apache.poi.hssf.record.Record;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 

--- a/src/test/java/com/sqlsheet/XLS2CSVmra.java
+++ b/src/test/java/com/sqlsheet/XLS2CSVmra.java
@@ -22,6 +22,7 @@ import org.apache.poi.hssf.eventusermodel.dummyrecord.LastCellOfRowDummyRecord;
 import org.apache.poi.hssf.eventusermodel.dummyrecord.MissingCellDummyRecord;
 import org.apache.poi.hssf.model.HSSFFormulaParser;
 import org.apache.poi.hssf.record.*;
+import org.apache.poi.hssf.record.Record;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 

--- a/src/test/java/com/sqlsheet/XlsConnectionURLResolverTest.java
+++ b/src/test/java/com/sqlsheet/XlsConnectionURLResolverTest.java
@@ -116,6 +116,8 @@ public class XlsConnectionURLResolverTest {
 
   @Test
   public void connectionFromTildeHome() throws Exception {
+	    if (XlsDriver.isWindows()) return;
+	  
 		conn =
         DriverManager.getConnection(
             "jdbc:xls:file://~/"


### PR DESCRIPTION
Tilde replacement causes 184 tests to fail if run on Windows. Problem is that tildes have a special meaning on Windows, which is different from Unix behaviour. Esp. for temp files there are frequently paths like "C:\Users\HILDEB~1\AppData\Local\Temp\testXlsConnectWriteStream10954043708817381594.xlsx" of course creating problems if the tilde is replaced by the home folder.